### PR TITLE
Fix bug in last n games stats

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -156,7 +156,7 @@ def get_last_n_games_dict(completed_games, n_lst, teams_on_date=None):
             else:
                 vals = []
                 for idx, row in team_data.iterrows():
-                    vals.append(row['toeam_adj_margin'])
+                    vals.append(row['team_adj_margin'])
                 team_val = np.mean(vals)
             team_vals[team] = team_val
             res[n][team] = team_val


### PR DESCRIPTION
## Summary
- fix typo in `get_last_n_games_dict` calculation

## Testing
- `python -m py_compile utils.py`
- `python -m py_compile main.py forecast.py eval.py stats.py data_loader.py sim_season.py env.py`

------
https://chatgpt.com/codex/tasks/task_e_6842ce37ce7c832f9529b860826c881b