### PR TITLE
Fix get_team_names year argument usage

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -14,7 +14,6 @@ def get_team_names(year=2025):
     '''
     Returns a dictionary of team names to abbreviations
     '''
-    year = 2025
     names_to_abbr = {}
     names_to_abbr['Houston Rockets'] = 'HOU'
     schedule = Schedule('HOU', year=year)


### PR DESCRIPTION
## Summary
- remove hardcoded year assignment in `get_team_names`
- ensure the schedule uses the passed in `year` parameter

## Testing
- `python -m py_compile data_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_6842cf5d49bc832fbb9becaeacad4871