### PR TITLE
Improve environment configuration

### DIFF
--- a/env.py
+++ b/env.py
@@ -1,6 +1,69 @@
-x_features = ['team_rating', 'opponent_rating', 'team_win_total_future', 'opponent_win_total_future', 'last_year_team_rating', 'last_year_opponent_rating', 'num_games_into_season', 'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating', 'team_days_since_most_recent_game', 'opponent_days_since_most_recent_game']
-x_features_heavy = x_features.copy()
-margin_label = 'margin'
-win_prob_label = 'win'
-win_margin_model_params = {'n_estimators': 127, 'max_depth': 3, 'learning_rate': 0.05277779665608899, 'subsample': 0.9828987652763124, 'colsample_bytree': 0.6867888479797172, 'gamma': 0.845516600015586, 'reg_alpha': 0.14855521764812535, 'reg_lambda': 0.5708849537577776, 'min_child_weight': 1.1864436159788416}
-win_prob_model_params = {'max_depth': 5, 'learning_rate': 0.01337501236333186, 'n_estimators': 615, 'min_child_weight': 6, 'gamma': 0.22171810700204012, 'subsample': 0.23183800840898533, 'colsample_bytree': 0.29826505641378537, 'reg_alpha': 0.5869931848470185, 'reg_lambda': 0.01392437600344064, 'random_state': 931}
+from dataclasses import dataclass, field
+from typing import List, Dict
+import os
+
+@dataclass
+class Config:
+    """Configuration for model training and data locations."""
+    data_dir: str = field(default_factory=lambda: os.getenv("NBA_DATA_DIR", "data"))
+    x_features: List[str] = field(default_factory=lambda: [
+        'team_rating',
+        'opponent_rating',
+        'team_win_total_future',
+        'opponent_win_total_future',
+        'last_year_team_rating',
+        'last_year_opponent_rating',
+        'num_games_into_season',
+        'team_last_10_rating',
+        'opponent_last_10_rating',
+        'team_last_5_rating',
+        'opponent_last_5_rating',
+        'team_last_3_rating',
+        'opponent_last_3_rating',
+        'team_last_1_rating',
+        'opponent_last_1_rating',
+        'team_days_since_most_recent_game',
+        'opponent_days_since_most_recent_game',
+    ])
+    margin_label: str = 'margin'
+    win_prob_label: str = 'win'
+    win_margin_model_params: Dict[str, float] = field(default_factory=lambda: {
+        'n_estimators': 127,
+        'max_depth': 3,
+        'learning_rate': 0.05277779665608899,
+        'subsample': 0.9828987652763124,
+        'colsample_bytree': 0.6867888479797172,
+        'gamma': 0.845516600015586,
+        'reg_alpha': 0.14855521764812535,
+        'reg_lambda': 0.5708849537577776,
+        'min_child_weight': 1.1864436159788416,
+    })
+    win_prob_model_params: Dict[str, float] = field(default_factory=lambda: {
+        'max_depth': 5,
+        'learning_rate': 0.01337501236333186,
+        'n_estimators': 615,
+        'min_child_weight': 6,
+        'gamma': 0.22171810700204012,
+        'subsample': 0.23183800840898533,
+        'colsample_bytree': 0.29826505641378537,
+        'reg_alpha': 0.5869931848470185,
+        'reg_lambda': 0.01392437600344064,
+        'random_state': 931,
+    })
+    x_features_heavy: List[str] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.x_features_heavy = self.x_features.copy()
+
+
+config = Config()
+
+# Backwards compatibility for existing imports
+DATA_DIR = config.data_dir
+x_features = config.x_features
+x_features_heavy = config.x_features_heavy
+margin_label = config.margin_label
+win_prob_label = config.win_prob_label
+win_margin_model_params = config.win_margin_model_params
+win_prob_model_params = config.win_prob_model_params
+

--- a/eval.py
+++ b/eval.py
@@ -6,6 +6,7 @@ from scipy.interpolate import UnivariateSpline
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.model_selection import train_test_split
+import os
 from xgboost import XGBClassifier, XGBRegressor
 from sklearn.metrics import log_loss
 import env
@@ -102,7 +103,7 @@ def get_win_margin_model(games, features=None):
     m, std = prediction_interval_stdev(model, X_test, y_test)
 
     # Save the trained model
-    filename = 'win_margin_model_heavy.pkl'
+    filename = os.path.join(env.DATA_DIR, 'win_margin_model_heavy.pkl')
     pickle.dump(model, open(filename, 'wb'))
     
     return model, m, std, spline

--- a/forecast.py
+++ b/forecast.py
@@ -1,7 +1,9 @@
 import datetime
+import os
 
 import numpy as np
 import pandas as pd
+import env
 
 
 def predict_margin_today_games(games, win_margin_model):
@@ -65,7 +67,7 @@ def predict_margin_this_week_games(games, win_margin_model):
             to_csv_data.append([row['date'], row['team'], row['opponent'], round(row['margin'], 1)])
         print()
     to_csv_data = pd.DataFrame(to_csv_data, columns=['Date', 'Home', 'Away', 'Predicted Home Margin'])
-    to_csv_data.to_csv('data/predicted_margins.csv', index=False)
+    to_csv_data.to_csv(os.path.join(env.DATA_DIR, 'predicted_margins.csv'), index=False)
     return games
 
 def predict_win_prob_this_week_games(games, win_prob_model):
@@ -91,8 +93,8 @@ def predict_margin_and_win_prob_future_games(games, win_margin_model, win_prob_m
         print()
     
     to_csv_data = pd.DataFrame(to_csv_data, columns=['Date', 'Home', 'Away', 'Predicted Home Margin', 'Predicted Home Win Probability'])
-    to_csv_data.to_csv('data/predictions/predicted_margins_and_win_probs.csv', index=False)
-    to_csv_data.to_csv('data/predictions/archive/predicted_margins_and_win_probs_{}.csv'.format(datetime.date.today()), index=False)
+    to_csv_data.to_csv(os.path.join(env.DATA_DIR, 'predictions', 'predicted_margins_and_win_probs.csv'), index=False)
+    to_csv_data.to_csv(os.path.join(env.DATA_DIR, 'predictions', 'archive', f'predicted_margins_and_win_probs_{datetime.date.today()}.csv'), index=False)
     return games
 
 def get_predictive_ratings_win_margin(teams, model, year):
@@ -102,7 +104,7 @@ def get_predictive_ratings_win_margin(teams, model, year):
     ['team_rating', 'opponent_rating', 'team_win_total_future', 'opponent_win_total_future', 'last_year_team_rating', 'last_year_opponent_rating', 'num_games_into_season', \
     'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating'])
     '''
-    filename = 'data/train_data.csv'
+    filename = os.path.join(env.DATA_DIR, 'train_data.csv')
     most_recent_games_dict = {} # team to pandas series of most recent game
     # most recent game is either the most recently played game OR the next game to be played (if no games have been played yet)
     this_year_games = pd.read_csv(filename)[pd.read_csv(filename)['year'] == year]
@@ -185,7 +187,7 @@ def get_predictive_ratings_win_margin(teams, model, year):
     
     team_predictive_em_df = pd.DataFrame.from_dict(team_predictive_em, orient='index', columns=['expected_margin'])
     team_predictive_em_df = team_predictive_em_df.sort_values(by='expected_margin', ascending=False)
-    team_predictive_em_df.to_csv('data/predictive_ratings.csv')
+    team_predictive_em_df.to_csv(os.path.join(env.DATA_DIR, 'predictive_ratings.csv'))
     return team_predictive_em_df
 
 def get_expected_wins_losses(all_data, future_games_with_win_probs):

--- a/sim_season.py
+++ b/sim_season.py
@@ -2,6 +2,9 @@ import datetime
 import random
 import time
 from random import choice
+import os
+
+import env
 
 import numpy as np
 import pandas as pd
@@ -1135,12 +1138,12 @@ def write_seed_report(seeds_results_over_sims):
     west_teams = ['DAL', 'DEN', 'GSW', 'HOU', 'LAC', 'LAL', 'MEM', 'MIN', 'NOP', 'OKC', 'PHO', 'POR', 'SAC', 'SAS', 'UTA']
     east_df = seeds_results_over_sims_df[seeds_results_over_sims_df['team'].isin(east_teams)]
     west_df = seeds_results_over_sims_df[seeds_results_over_sims_df['team'].isin(west_teams)]
-    east_df.to_csv('data/seed_reports/archive/east_seed_report_' + date_string + '.csv', index=False)
-    east_df.to_csv('data/seed_reports/east_seed_report.csv', index=False)
-    west_df.to_csv('data/seed_reports/archive/west_seed_report_' + date_string + '.csv', index=False)
-    west_df.to_csv('data/seed_reports/west_seed_report.csv', index=False)
-    seeds_results_over_sims_df.to_csv('data/seed_reports/archive/seed_report_' + date_string + '.csv', index=False)
-    seeds_results_over_sims_df.to_csv('data/seed_reports/seed_report.csv', index=False)
+    east_df.to_csv(os.path.join(env.DATA_DIR, 'seed_reports', 'archive', f'east_seed_report_{date_string}.csv'), index=False)
+    east_df.to_csv(os.path.join(env.DATA_DIR, 'seed_reports', 'east_seed_report.csv'), index=False)
+    west_df.to_csv(os.path.join(env.DATA_DIR, 'seed_reports', 'archive', f'west_seed_report_{date_string}.csv'), index=False)
+    west_df.to_csv(os.path.join(env.DATA_DIR, 'seed_reports', 'west_seed_report.csv'), index=False)
+    seeds_results_over_sims_df.to_csv(os.path.join(env.DATA_DIR, 'seed_reports', 'archive', f'seed_report_{date_string}.csv'), index=False)
+    seeds_results_over_sims_df.to_csv(os.path.join(env.DATA_DIR, 'seed_reports', 'seed_report.csv'), index=False)
 
 def sim_season(data, win_margin_model, win_prob_model, margin_model_resid_mean, margin_model_resid_std, num_games_to_std_margin_model_resid, mean_pace, std_pace, year, num_sims=1000, parallel=True):
     import multiprocessing


### PR DESCRIPTION
## Summary
- encapsulate config variables in `env.Config`
- reference new `DATA_DIR` across loader, forecast, simulation and main scripts
- save models into the configured data directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68476e30b7d4832f854dd66dd8d86b15