### PR TITLE
Add rating differential feature to model

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -246,12 +246,14 @@ def load_training_data(names, update=True, reset=False, start_year=2010, stop_ye
 
         # all_data = pd.DataFrame(all_data, columns=['team', 'opponent', 'team_rating', 'opponent_rating', 'last_year_team_rating', 'last_year_opponent_rating', 'margin','pace', 'num_games_into_season', 'date', 'year', 'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating', 'completed', 'team_win_total_future', 'opponent_win_total_future', 'team_days_since_most_recent_game', 'opponent_days_since_most_recent_game'])
         all_data = pd.DataFrame(all_data)
+        all_data['rating_diff'] = all_data['team_rating'] - all_data['opponent_rating']
         all_data.to_csv(f'data/train_data.csv', index=False)
     else:
         all_data = pd.read_csv(f'data/train_data.csv')
         all_data.drop([col for col in all_data.columns if 'Unnamed' in col], axis=1, inplace=True)
         all_data['team_win_total_future'] = all_data.apply(lambda x: win_totals_futures[str(x['year'])][x['team']], axis=1).astype(float)
         all_data['opponent_win_total_future'] = all_data.apply(lambda x: win_totals_futures[str(x['year'])][x['opponent']], axis=1).astype(float)
+        all_data['rating_diff'] = all_data['team_rating'] - all_data['opponent_rating']
         all_data.to_csv(f'data/train_data.csv')
     
     all_data = add_days_since_most_recent_game(all_data)

--- a/env.py
+++ b/env.py
@@ -1,4 +1,4 @@
-x_features = ['team_rating', 'opponent_rating', 'team_win_total_future', 'opponent_win_total_future', 'last_year_team_rating', 'last_year_opponent_rating', 'num_games_into_season', 'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating', 'team_days_since_most_recent_game', 'opponent_days_since_most_recent_game']
+x_features = ['team_rating', 'opponent_rating', 'rating_diff', 'team_win_total_future', 'opponent_win_total_future', 'last_year_team_rating', 'last_year_opponent_rating', 'num_games_into_season', 'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating', 'team_days_since_most_recent_game', 'opponent_days_since_most_recent_game']
 x_features_heavy = x_features.copy()
 margin_label = 'margin'
 win_prob_label = 'win'

--- a/forecast.py
+++ b/forecast.py
@@ -12,7 +12,8 @@ def predict_margin_today_games(games, win_margin_model):
     games = games[games['date'] == datetime.date.today()]
     if len(games) == 0:
         return None
-    games['margin'] = win_margin_model.predict(games[['team_rating', 'opponent_rating', 'team_win_total_future','opponent_win_total_future', 'last_year_team_rating', 'last_year_opponent_rating', 'num_games_into_season', 'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating', 'team_days_since_most_recent_game', 'opponent_days_since_most_recent_game']])
+    games['rating_diff'] = games['team_rating'] - games['opponent_rating']
+    games['margin'] = win_margin_model.predict(games[['team_rating', 'opponent_rating', 'rating_diff', 'team_win_total_future','opponent_win_total_future', 'last_year_team_rating', 'last_year_opponent_rating', 'num_games_into_season', 'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating', 'team_days_since_most_recent_game', 'opponent_days_since_most_recent_game']])
     for date in games['date'].unique():
         print('{} games'.format(date))
         for index, row in games[games['date'] == date].iterrows():
@@ -41,14 +42,15 @@ def predict_margin_this_week_games(games, win_margin_model):
         print(f"\n{col}:")
         print(games[col].describe())
         
-    games['margin'] = win_margin_model.predict(games[['team_rating', 'opponent_rating', 'team_win_total_future',
-                                                    'opponent_win_total_future', 'last_year_team_rating', 
-                                                    'last_year_opponent_rating', 'num_games_into_season', 
-                                                    'team_last_10_rating', 'opponent_last_10_rating', 
-                                                    'team_last_5_rating', 'opponent_last_5_rating', 
-                                                    'team_last_3_rating', 'opponent_last_3_rating', 
+    games['rating_diff'] = games['team_rating'] - games['opponent_rating']
+    games['margin'] = win_margin_model.predict(games[['team_rating', 'opponent_rating', 'rating_diff', 'team_win_total_future',
+                                                    'opponent_win_total_future', 'last_year_team_rating',
+                                                    'last_year_opponent_rating', 'num_games_into_season',
+                                                    'team_last_10_rating', 'opponent_last_10_rating',
+                                                    'team_last_5_rating', 'opponent_last_5_rating',
+                                                    'team_last_3_rating', 'opponent_last_3_rating',
                                                     'team_last_1_rating', 'opponent_last_1_rating',
-                                                    'team_days_since_most_recent_game', 
+                                                    'team_days_since_most_recent_game',
                                                     'opponent_days_since_most_recent_game']])
                                                     
     print("\nPredicted Margins by Date:")
@@ -80,7 +82,8 @@ def predict_margin_and_win_prob_future_games(games, win_margin_model, win_prob_m
     games = games[games['date'] >= datetime.date.today()]
     if len(games) == 0:
         return None
-    games['pred_margin'] = win_margin_model.predict(games[['team_rating', 'opponent_rating', 'team_win_total_future','opponent_win_total_future', 'last_year_team_rating', 'last_year_opponent_rating', 'num_games_into_season', 'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating', 'team_days_since_most_recent_game', 'opponent_days_since_most_recent_game']])
+    games['rating_diff'] = games['team_rating'] - games['opponent_rating']
+    games['pred_margin'] = win_margin_model.predict(games[['team_rating', 'opponent_rating', 'rating_diff', 'team_win_total_future','opponent_win_total_future', 'last_year_team_rating', 'last_year_opponent_rating', 'num_games_into_season', 'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating', 'team_days_since_most_recent_game', 'opponent_days_since_most_recent_game']])
     games['win_prob'] = win_prob_model.predict_proba(games['pred_margin'].values.reshape(-1, 1))[:, 1]
 
     for date in games['date'].unique():
@@ -166,12 +169,12 @@ def get_predictive_ratings_win_margin(teams, model, year):
             opp_days_since_most_recent_game = 3
 
             # play a home game
-            X_home_dct = {'team_rating': team_rating, 'opponent_rating': opp_rating, 'team_win_total_future': team_win_total_future, 'opponent_win_total_future': opp_win_total_future, 'last_year_team_rating': last_year_ratings[team], 'last_year_opponent_rating': last_year_ratings[opp], 'num_games_into_season': num_games_into_season, 'team_last_10_rating': team_last_10_rating, 'opponent_last_10_rating': opp_last_10_rating, 'team_last_5_rating': team_last_5_rating, 'opponent_last_5_rating': opp_last_5_rating, 'team_last_3_rating': team_last_3_rating, 'opponent_last_3_rating': opp_last_3_rating, 'team_last_1_rating': team_last_1_rating_rating, 'opponent_last_1_rating': opp_last_1_rating_rating, 'team_days_since_most_recent_game': team_days_since_most_recent_game, 'opponent_days_since_most_recent_game': opp_days_since_most_recent_game}
+            X_home_dct = {'team_rating': team_rating, 'opponent_rating': opp_rating, 'rating_diff': team_rating - opp_rating, 'team_win_total_future': team_win_total_future, 'opponent_win_total_future': opp_win_total_future, 'last_year_team_rating': last_year_ratings[team], 'last_year_opponent_rating': last_year_ratings[opp], 'num_games_into_season': num_games_into_season, 'team_last_10_rating': team_last_10_rating, 'opponent_last_10_rating': opp_last_10_rating, 'team_last_5_rating': team_last_5_rating, 'opponent_last_5_rating': opp_last_5_rating, 'team_last_3_rating': team_last_3_rating, 'opponent_last_3_rating': opp_last_3_rating, 'team_last_1_rating': team_last_1_rating_rating, 'opponent_last_1_rating': opp_last_1_rating_rating, 'team_days_since_most_recent_game': team_days_since_most_recent_game, 'opponent_days_since_most_recent_game': opp_days_since_most_recent_game}
             X_home = pd.DataFrame.from_dict(X_home_dct, orient='index').transpose()
             team_home_margins.append(model.predict(X_home)[0])
 
             # play an away game
-            X_away_dct = {'team_rating': opp_rating, 'opponent_rating': team_rating, 'team_win_total_future': opp_win_total_future, 'opponent_win_total_future': team_win_total_future, 'last_year_team_rating': last_year_ratings[opp], 'last_year_opponent_rating': last_year_ratings[team], 'num_games_into_season': num_games_into_season, 'team_last_10_rating': opp_last_10_rating, 'opponent_last_10_rating': team_last_10_rating, 'team_last_5_rating': opp_last_5_rating, 'opponent_last_5_rating': team_last_5_rating, 'team_last_3_rating': opp_last_3_rating, 'opponent_last_3_rating': team_last_3_rating, 'team_last_1_rating': opp_last_1_rating_rating, 'opponent_last_1_rating': team_last_1_rating_rating, 'team_days_since_most_recent_game': opp_days_since_most_recent_game, 'opponent_days_since_most_recent_game': team_days_since_most_recent_game}
+            X_away_dct = {'team_rating': opp_rating, 'opponent_rating': team_rating, 'rating_diff': opp_rating - team_rating, 'team_win_total_future': opp_win_total_future, 'opponent_win_total_future': team_win_total_future, 'last_year_team_rating': last_year_ratings[opp], 'last_year_opponent_rating': last_year_ratings[team], 'num_games_into_season': num_games_into_season, 'team_last_10_rating': opp_last_10_rating, 'opponent_last_10_rating': team_last_10_rating, 'team_last_5_rating': opp_last_5_rating, 'opponent_last_5_rating': team_last_5_rating, 'team_last_3_rating': opp_last_3_rating, 'opponent_last_3_rating': team_last_3_rating, 'team_last_1_rating': opp_last_1_rating_rating, 'opponent_last_1_rating': team_last_1_rating_rating, 'team_days_since_most_recent_game': opp_days_since_most_recent_game, 'opponent_days_since_most_recent_game': team_days_since_most_recent_game}
             X_away = pd.DataFrame.from_dict(X_away_dct, orient='index').transpose()
             team_away_margins.append(-model.predict(X_away)[0])
 

--- a/sim_season.py
+++ b/sim_season.py
@@ -30,9 +30,11 @@ class Season:
     def __init__(self, year, completed_games, future_games, margin_model, win_prob_model, mean_pace, std_pace, sim_date_increment=1):
         self.year = year
         self.completed_games = completed_games
+        self.completed_games['rating_diff'] = self.completed_games['team_rating'] - self.completed_games['opponent_rating']
         self.completed_games['winner_name'] = self.completed_games.apply(lambda row: row['team'] if row['margin'] > 0 else row['opponent'], axis=1)
         self.completed_games['team_win'] = self.completed_games.apply(lambda row: 1 if row['margin'] > 0 else 0, axis=1)
         self.future_games = future_games
+        self.future_games['rating_diff'] = self.future_games['team_rating'] - self.future_games['opponent_rating']
         self.future_games['winner_name'] = np.nan
         self.margin_model = margin_model
         self.win_prob_model = win_prob_model
@@ -179,6 +181,7 @@ class Season:
 
         self.future_games['team_rating'] = self.future_games['team'].map(self.em_ratings)
         self.future_games['opponent_rating'] = self.future_games['opponent'].map(self.em_ratings)
+        self.future_games['rating_diff'] = self.future_games['team_rating'] - self.future_games['opponent_rating']
 
         self.future_games['team_days_since_most_recent_game'] = self.future_games.apply(lambda row: 10 if self.most_recent_game_date_dict[row['team']] is None else min(int((row['date'] - self.most_recent_game_date_dict[row['team']]).days), 10), axis=1)
         self.future_games['opponent_days_since_most_recent_game'] = self.future_games.apply(lambda row: 10 if self.most_recent_game_date_dict[row['opponent']] is None else min(int((row['date'] - self.most_recent_game_date_dict[row['opponent']]).days), 10), axis=1)
@@ -261,6 +264,7 @@ class Season:
         row['team_win'] = team_win
         row['margin'] = margin
         row['winner_name'] = team if team_win else opponent
+        row['rating_diff'] = row['team_rating'] - row['opponent_rating']
 
         team_adj_margin = row['margin'] + row['opponent_rating'] - utils.HCA
         opponent_adj_margin = -row['margin'] + row['team_rating'] + utils.HCA
@@ -289,7 +293,8 @@ class Season:
         team_days_since_most_recent_game = row['team_days_since_most_recent_game']
         opponent_days_since_most_recent_game = row['opponent_days_since_most_recent_game']
 
-        data = pd.DataFrame([[team_rating, opp_rating, team_win_total_future, opponent_win_total_future, last_year_team_rating, last_year_opp_rating, num_games_into_season, team_last_10_rating, opponent_last_10_rating, team_last_5_rating, opponent_last_5_rating, team_last_3_rating, opponent_last_3_rating, team_last_1_rating, opponent_last_1_rating, team_days_since_most_recent_game, opponent_days_since_most_recent_game]], columns=['team_rating', 'opponent_rating', 'team_win_total_future', 'opponent_win_total_future', 'last_year_team_rating', 'last_year_opponent_rating', 'num_games_into_season', 'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating', 'team_days_since_most_recent_game', 'opponent_days_since_most_recent_game'])
+        rating_diff = team_rating - opp_rating
+        data = pd.DataFrame([[team_rating, opp_rating, rating_diff, team_win_total_future, opponent_win_total_future, last_year_team_rating, last_year_opp_rating, num_games_into_season, team_last_10_rating, opponent_last_10_rating, team_last_5_rating, opponent_last_5_rating, team_last_3_rating, opponent_last_3_rating, team_last_1_rating, opponent_last_1_rating, team_days_since_most_recent_game, opponent_days_since_most_recent_game]], columns=['team_rating', 'opponent_rating', 'rating_diff', 'team_win_total_future', 'opponent_win_total_future', 'last_year_team_rating', 'last_year_opponent_rating', 'num_games_into_season', 'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating', 'team_days_since_most_recent_game', 'opponent_days_since_most_recent_game'])
         return data
 
     def get_win_loss_report(self):

--- a/tests/test_duplicate_games.py
+++ b/tests/test_duplicate_games.py
@@ -10,6 +10,7 @@ def test_duplicate_games_basic():
             "margin": 10,
             "team_rating": 100,
             "opponent_rating": 90,
+            "rating_diff": 10,
             "last_year_team_rating": 95,
             "last_year_opponent_rating": 92,
             "team_last_10_rating": 101,
@@ -35,4 +36,5 @@ def test_duplicate_games_basic():
     assert dup["team"] == "B"
     assert dup["opponent"] == "A"
     assert dup["margin"] == -10 + 2 * utils.HCA
+    assert dup["rating_diff"] == -10
 

--- a/utils.py
+++ b/utils.py
@@ -274,6 +274,10 @@ def duplicate_games(df):
     }
     
     duplicated_games = duplicated_games.rename(columns=col_mapping)
+
+    # Recompute rating differential after swapping
+    if 'team_rating' in duplicated_games.columns and 'opponent_rating' in duplicated_games.columns:
+        duplicated_games['rating_diff'] = duplicated_games['team_rating'] - duplicated_games['opponent_rating']
     
     # Adjust columns that require calculation
     duplicated_games['margin'] = -duplicated_games['margin'] + 2 * HCA
@@ -325,7 +329,7 @@ def duplicate_games(df):
 #     return df
 
 def duplicate_games_training_data(df):
-    features = ['team', 'opponent', 'team_rating', 'opponent_rating', 'last_year_team_rating', 'last_year_opponent_rating', 'margin', 'num_games_into_season', 'date', 'year', 'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating', 'completed', 'team_win_total_future', 'opponent_win_total_future']
+    features = ['team', 'opponent', 'team_rating', 'opponent_rating', 'rating_diff', 'last_year_team_rating', 'last_year_opponent_rating', 'margin', 'num_games_into_season', 'date', 'year', 'team_last_10_rating', 'opponent_last_10_rating', 'team_last_5_rating', 'opponent_last_5_rating', 'team_last_3_rating', 'opponent_last_3_rating', 'team_last_1_rating', 'opponent_last_1_rating', 'completed', 'team_win_total_future', 'opponent_win_total_future']
     def reverse_game(row):
         team = row['opponent']
         opponent = row['team']
@@ -348,12 +352,15 @@ def duplicate_games_training_data(df):
         completed = row['completed']
         team_win_total_future = row['opponent_win_total_future']
         opponent_win_total_future = row['team_win_total_future']
-        return [team, opponent, team_rating, opponent_rating, last_year_team_rating, last_year_opponent_rating, margin, num_games_into_season, date, year, team_last_10_rating, opponent_last_10_rating, team_last_5_rating, opponent_last_5_rating, team_last_3_rating, opponent_last_3_rating, team_last_1_rating, opponent_last_1_rating, completed, team_win_total_future, opponent_win_total_future]
+        rating_diff = team_rating - opponent_rating
+        return [team, opponent, team_rating, opponent_rating, rating_diff, last_year_team_rating, last_year_opponent_rating, margin, num_games_into_season, date, year, team_last_10_rating, opponent_last_10_rating, team_last_5_rating, opponent_last_5_rating, team_last_3_rating, opponent_last_3_rating, team_last_1_rating, opponent_last_1_rating, completed, team_win_total_future, opponent_win_total_future]
     
     duplicated_games = []
     for idx, game in df.iterrows():
         duplicated_games.append(reverse_game(game))
     duplicated_games = pd.DataFrame(duplicated_games, columns=features)
+    if 'rating_diff' in df.columns:
+        df['rating_diff'] = df['team_rating'] - df['opponent_rating']
     df = pd.concat([df, duplicated_games])
     return df
 


### PR DESCRIPTION
## Summary
- compute rating_diff for training data
- include rating_diff in env feature lists
- incorporate rating_diff in forecasting and simulation logic
- update duplication utilities and tests

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68477091c5c0832f8bf2be9bac1d35a2