### PR TITLE
Add start-date option for season simulator

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import pickle
 import sys
 import time
 import warnings
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Optional
 
 import numpy as np
 import pandas as pd
@@ -39,6 +39,12 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--reset", action="store_true", help="Reset training data")
     parser.add_argument(
         "--parallel", action="store_true", help="Run simulations in parallel"
+    )
+    parser.add_argument(
+        "--start-date",
+        type=str,
+        default=None,
+        help="Start date for simulation in YYYY-MM-DD format",
     )
     return parser.parse_args()
 
@@ -191,6 +197,7 @@ def simulate_season(
     year: int,
     num_sims: int,
     parallel: bool = False,
+    start_date: Optional[str] = None,
 ) -> pd.DataFrame:
     (
         win_margin_model,
@@ -211,6 +218,7 @@ def simulate_season(
         year=year,
         num_sims=num_sims,
         parallel=parallel,
+        start_date=start_date,
     )
     date_string = datetime.datetime.today().strftime("%Y-%m-%d")
     sim_report.to_csv(os.path.join(env.DATA_DIR, "sim_results", "sim_report.csv"))
@@ -365,6 +373,7 @@ def main():
     num_sims = args.num_sims
     reset = args.reset
     parallel = args.parallel
+    start_date = args.start_date
 
     # Load team data
     abbrs, names_to_abbr, abbr_to_name = load_team_data(YEAR, update, save_names)
@@ -409,6 +418,7 @@ def main():
         year=YEAR,
         num_sims=num_sims,
         parallel=parallel,
+        start_date=start_date,
     )
 
     # Add predictive ratings

--- a/sim_season.py
+++ b/sim_season.py
@@ -1815,6 +1815,7 @@ def sim_season(
     year,
     num_sims=1000,
     parallel=True,
+    start_date=None,
 ):
     import multiprocessing
 
@@ -1842,8 +1843,15 @@ def sim_season(
         num_games_to_std_margin_model_resid,
     )
     year_games = data[data["year"] == year]
-    completed_year_games = year_games[year_games["completed"] == True]
-    future_year_games = year_games[year_games["completed"] == False]
+    if start_date is not None:
+        start_dt = pd.to_datetime(start_date).date()
+        completed_year_games = year_games[year_games["date"] < start_dt].copy()
+        future_year_games = year_games[year_games["date"] >= start_dt].copy()
+        completed_year_games["completed"] = True
+        future_year_games["completed"] = False
+    else:
+        completed_year_games = year_games[year_games["completed"] == True]
+        future_year_games = year_games[year_games["completed"] == False]
 
     start_time = time.time()
     if parallel:

--- a/tests/test_main_run.py
+++ b/tests/test_main_run.py
@@ -73,7 +73,13 @@ class DummyGames:
 
 # Replace heavy functions with simple stubs
 main.parse_arguments = lambda: argparse.Namespace(
-    year=2025, update=False, save_names=False, num_sims=10, reset=False, parallel=False
+    year=2025,
+    update=False,
+    save_names=False,
+    num_sims=10,
+    reset=False,
+    parallel=False,
+    start_date=None,
 )
 main.load_team_data = lambda *a, **k: (["A"], {"Alpha": "A"}, {"A": "Alpha"})
 main.load_game_data = lambda *a, **k: DummyGames()


### PR DESCRIPTION
## Summary
- allow specifying a simulation start date
- wire start_date through main into sim_season
- adjust tests for new CLI option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852bf3e9e20832f96b4f51de7b6efe9